### PR TITLE
Acccept dict of arrays

### DIFF
--- a/bluesky_live/run_builder.py
+++ b/bluesky_live/run_builder.py
@@ -371,7 +371,7 @@ def _infer_dtype(obj):
             obj = obj.item()
         else:
             return "array"
-    elif isinstance(obj, str):
+    if isinstance(obj, str):
         return "string"
     elif isinstance(obj, collections.abc.Iterable):
         return "array"

--- a/bluesky_live/tests/test_run_builder.py
+++ b/bluesky_live/tests/test_run_builder.py
@@ -1,3 +1,4 @@
+import numpy
 import pandas
 import pytest
 import xarray
@@ -69,18 +70,23 @@ def test_add_stream_from_data_keys():
     run.primary
 
 
-@pytest.mark.parametrize(
+data_param = pytest.mark.parametrize(
     "data",
     [
         {"x": [1, 2, 3], "y": [10, 20, 30]},
+        {"x": numpy.array([1, 2, 3]), "y": numpy.array([10, 20, 30])},
         pandas.DataFrame({"x": [4, 5, 6], "y": [40, 50, 60]}),
         xarray.Dataset(
             {"x": xarray.DataArray([7, 8, 9]), "y": xarray.DataArray([70, 80, 90])}
         ),
     ],
-    ids=["dict-of-lists", "pandas.DataFrame", "xarray.Dataset"],
+    ids=["dict-of-lists", "dict-of-arrays", "pandas.DataFrame", "xarray.Dataset"],
 )
-def test_add_data_from_various_structures(data):
+
+
+@data_param
+def test_add_stream_and_add_data(data):
+    "Declare a new stream with data_keys and then add data separately."
     with RunBuilder() as builder:
         builder.add_stream(
             "primary",
@@ -92,11 +98,28 @@ def test_add_data_from_various_structures(data):
         builder.add_data("primary", data)
 
 
-def test_add_stream_from_data():
+@data_param
+def test_add_stream_with_data_keys_and_data(data):
+    "Declare a new stream with data_keys and some data."
     with RunBuilder() as builder:
-        builder.add_stream("baseline", data={"a": [1, 1, 2, 3, 5, 8]})
-    run = builder.get_run()
-    run.baseline.read()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "x": {"source": "made up", "dtype": "number", "shape": []},
+                "y": {"source": "made up", "dtype": "number", "shape": []},
+            },
+            data=data,
+        )
+
+
+@data_param
+def test_add_stream_with_data_only(data):
+    "Declare a new stream with data only, inferring the data_keys."
+    with RunBuilder() as builder:
+        builder.add_stream(
+            "primary",
+            data=data,
+        )
 
 
 def test_add_stream_from_data_keys_with_extras():

--- a/bluesky_live/tests/test_run_builder.py
+++ b/bluesky_live/tests/test_run_builder.py
@@ -69,7 +69,18 @@ def test_add_stream_from_data_keys():
     run.primary
 
 
-def test_add_data_from_various_structures():
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"x": [1, 2, 3], "y": [10, 20, 30]},
+        pandas.DataFrame({"x": [4, 5, 6], "y": [40, 50, 60]}),
+        xarray.Dataset(
+            {"x": xarray.DataArray([7, 8, 9]), "y": xarray.DataArray([70, 80, 90])}
+        ),
+    ],
+    ids=["dict-of-lists", "pandas.DataFrame", "xarray.Dataset"],
+)
+def test_add_data_from_various_structures(data):
     with RunBuilder() as builder:
         builder.add_stream(
             "primary",
@@ -78,16 +89,7 @@ def test_add_data_from_various_structures():
                 "y": {"source": "made up", "dtype": "number", "shape": []},
             },
         )
-        builder.add_data("primary", {"x": [1, 2, 3], "y": [10, 20, 30]})
-        builder.add_data(
-            "primary", pandas.DataFrame({"x": [4, 5, 6], "y": [40, 50, 60]})
-        )
-        builder.add_data(
-            "primary",
-            xarray.Dataset(
-                {"x": xarray.DataArray([7, 8, 9]), "y": xarray.DataArray([70, 80, 90])}
-            ),
-        )
+        builder.add_data("primary", data)
 
 
 def test_add_stream_from_data():


### PR DESCRIPTION
This adds a bunch more tests and fixes a bug that @dleshchev and I hit wherein `add_stream(..., data=...)` accepted a dict-of-lists but not dict-of-arrays.