### PR TITLE
Reading an empty stream should return xarray with correct shapes.

### DIFF
--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -15,6 +15,20 @@ def test_empty():
         BlueskyRun(dc)
 
 
+def test_read_empty_stream():
+    "An empty stream should return a xarray with no data but the right columns."
+
+    with RunBuilder() as builder:
+        builder.add_stream(
+            "primary",
+            data_keys={"a": {"shape": [10, 10], "dtype": "number", "source": "stuff"}},
+        )
+    run = builder.get_run()
+    ds = run.primary.read()
+    assert "a" in ds
+    assert ds["a"].shape == (0, 10, 10)
+
+
 def test_events():
     "Test the Event EmitterGroup on BlueskyRun."
     # We will subscribe callbacks that appent Events to these lists.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask[array]
+dask[array] >=2
 entrypoints
 event-model >=1.16.0
 numpy


### PR DESCRIPTION
Before:

```py
In [2]: from bluesky_live.run_builder import RunBuilder
   ...: builder = RunBuilder()
   ...: run = builder.get_run()
   ...: builder.add_stream("primary", data_keys={"a": {"shape": [10, 10], "dtype": "number", "source": "stuff"}})
   ...: run.primary.read()
   ...: 
   ...: 
Out[2]: 
<xarray.Dataset>
Dimensions:  ()
Data variables:
    *empty*
```

After:

```py
In [1]: from bluesky_live.run_builder import RunBuilder
   ...: builder = RunBuilder()
   ...: run = builder.get_run()
   ...: builder.add_stream("primary", data_keys={"a": {"shape": [10, 10], "dtype": "number", "source": "stuff"}})
   ...: run.primary.read()
Out[1]: 
<xarray.Dataset>
Dimensions:  (dim_0: 10, dim_1: 10, time: 0)
Coordinates:
  * time     (time) float64 
Dimensions without coordinates: dim_0, dim_1
Data variables:
    a        (time, dim_0, dim_1) float64 
```

Note: Supporting this required removing a workaround that provided support for `dask < 2`. I have updated the `requirements.txt` accordingly.