### PR TITLE
Add a write_lock to BlueskyRun, DocumentCache

### DIFF
--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -2,6 +2,7 @@ import collections
 import collections.abc
 from datetime import datetime
 import functools
+import threading
 
 import event_model
 
@@ -30,6 +31,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
     """
 
     def __init__(self):
+        self.write_lock = threading.RLock()
         self.descriptors = {}
         self.resources = {}
         self.event_pages = collections.defaultdict(list)
@@ -120,6 +122,7 @@ class BlueskyRun(collections.abc.Mapping):
                 "The document_cache must at least have a 'start' doc before a BlueskyRun can be created from it."
             )
         self._document_cache = document_cache
+        self.write_lock = self._document_cache.write_lock
         self._streams = {}
 
         self._root_map = root_map or {}
@@ -193,7 +196,6 @@ class BlueskyRun(collections.abc.Mapping):
             self.events.new_stream(name=event.name, run=self)
 
         self._document_cache.events.new_stream.connect(on_new_stream)
-
 
     # The following three methods are required to implement the Mapping interface.
 


### PR DESCRIPTION
In bluesky-widgets, when we call a series of user-defined functions on a `BlueskyRun`, data may be added to the `BlueskyRun` between function calls. This can lead to inconsistencies like an equal number of x points and y points to plot.

This PR provides a solution by adding a public `write_lock` which may be held to temporarily block data from being added to the `BlueskyRun` (or, to be precise, to the `DocumentCache` where its data is stored).

To verify that this behaves as intended, I wrote a failing test first a separate commit from the fix.