### PR TITLE
ENH: make streaming updates easier

### DIFF
--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -124,7 +124,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
     def resource(self, doc):
         self._ordered.append(("resource", doc))
         self.resources[doc["uid"]] = doc
-        self.events.new_doc(name="datum_page", doc=doc)
+        self.events.new_doc(name="resource", doc=doc)
         super().resource(doc)
 
 

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -94,7 +94,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
         self.event_pages[doc["descriptor"]].append(doc)
         self.events.new_doc(name="event_page", doc=doc)
         self.events.new_data(
-            update={self.descriptors[doc["descriptor"]]["name"]: len(doc["seq_num"])}
+            updated={self.descriptors[doc["descriptor"]]["name"]: len(doc["seq_num"])}
         )
         super().event_page(doc)
 
@@ -184,7 +184,7 @@ class BlueskyRun(collections.abc.Mapping):
         # again) since we already have a 'start' document.
 
         self._document_cache.events.new_data.connect(
-            lambda event: self.events.new_data(run=self, update=event.update)
+            lambda event: self.events.new_data(run=self, updated=event.updated)
         )
         self._document_cache.events.new_doc.connect(
             lambda event: self.events.new_doc(run=self, name=event.name, doc=event.doc)

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -56,6 +56,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
             new_stream=Event,
             new_data=Event,
             completed=Event,
+            new_doc=Event,
         )
         # maps stream name to list of descriptors
         self._streams = {}
@@ -75,6 +76,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
     def start(self, doc):
         self.start_doc = doc
         self._ordered.append(("start", doc))
+        self.events.new_doc(name="start", doc=doc)
         self.events.started()
         super().start(doc)
 
@@ -82,6 +84,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
     def stop(self, doc):
         self._ordered.append(("stop", doc))
         self.stop_doc = doc
+        self.events.new_doc(name="stop", doc=doc)
         self.events.completed()
         super().stop(doc)
 
@@ -89,6 +92,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
     def event_page(self, doc):
         self._ordered.append(("event_page", doc))
         self.event_pages[doc["descriptor"]].append(doc)
+        self.events.new_doc(name="event_page", doc=doc)
         self.events.new_data()
         super().event_page(doc)
 
@@ -98,6 +102,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
         self.datum_pages_by_resource[doc["resource"]].append(doc)
         for datum_id in doc["datum_id"]:
             self.resource_uid_by_datum_id[datum_id] = doc["resource"]
+        self.events.new_doc(name="datum_page", doc=doc)
         super().datum_page(doc)
 
     @_write_locked
@@ -110,12 +115,14 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
             self.events.new_stream(name=name)
         else:
             self._streams[name].append(doc)
+        self.events.new_doc(name="descriptor", doc=doc)
         super().descriptor(doc)
 
     @_write_locked
     def resource(self, doc):
         self._ordered.append(("resource", doc))
         self.resources[doc["uid"]] = doc
+        self.events.new_doc(name="datum_page", doc=doc)
         super().resource(doc)
 
 
@@ -164,7 +171,11 @@ class BlueskyRun(collections.abc.Mapping):
         # difference is that these Events include a reference to self, and
         # thus subscribers will get a reference to this BlueskyRun.
         self.events = EmitterGroup(
-            source=self, new_stream=Event, new_data=Event, completed=Event
+            source=self,
+            new_stream=Event,
+            new_data=Event,
+            completed=Event,
+            new_doc=Event,
         )
         # We intentionally do not re-emit self._document_cache.started, because
         # by definition that will have fired already (and will never fire
@@ -172,6 +183,8 @@ class BlueskyRun(collections.abc.Mapping):
 
         self._document_cache.events.new_data.connect(
             lambda event: self.events.new_data(run=self)
+        self._document_cache.events.new_doc.connect(
+            lambda event: self.events.new_doc(run=self, name=event.name, doc=event.doc)
         )
         # The `completed` and `new_stream` Events are emitted below *after* we
         # update our internal state.

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -93,7 +93,9 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
         self._ordered.append(("event_page", doc))
         self.event_pages[doc["descriptor"]].append(doc)
         self.events.new_doc(name="event_page", doc=doc)
-        self.events.new_data()
+        self.events.new_data(
+            update={self.descriptors[doc["descriptor"]]["name"]: len(doc["seq_num"])}
+        )
         super().event_page(doc)
 
     @_write_locked
@@ -182,7 +184,8 @@ class BlueskyRun(collections.abc.Mapping):
         # again) since we already have a 'start' document.
 
         self._document_cache.events.new_data.connect(
-            lambda event: self.events.new_data(run=self)
+            lambda event: self.events.new_data(run=self, update=event.update)
+        )
         self._document_cache.events.new_doc.connect(
             lambda event: self.events.new_doc(run=self, name=event.name, doc=event.doc)
         )

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -38,12 +38,14 @@ def test_events():
     new_stream_events = list()
     new_data_events = list()
     completed_events = list()
+    new_doc_events = list()
 
     with RunBuilder() as builder:
         run = builder.get_run()
         run.events.new_stream.connect(lambda event: new_stream_events.append(event))
         run.events.new_data.connect(lambda event: new_data_events.append(event))
         run.events.completed.connect(lambda event: completed_events.append(event))
+        run.events.new_doc.connect(lambda event: new_doc_events.append(event))
         assert not new_stream_events
         assert not new_data_events
         assert not completed_events
@@ -68,6 +70,11 @@ def test_events():
     assert len(new_data_events) == 2
     assert len(completed_events) == 1
     assert completed_events[0].run is run
+
+    actual_docs = [(ev.name, ev.doc) for ev in new_doc_events]
+    # Omit first ('start') doc because subscriber is too late to see it.
+    expected_docs = list(run.documents(fill="no"))[1:]
+    assert actual_docs == expected_docs
 
 
 def test_access_stream_in_callback():

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -56,12 +56,14 @@ def test_events():
         assert new_stream_events[0].name == "primary"
         assert len(new_data_events) == 1
         assert new_data_events[0].run is run
+        assert new_data_events[0].updated == {"primary": 3}
         assert len(completed_events) == 0
 
         builder.add_data("primary", data={"a": [1, 2, 3]})
         assert len(new_stream_events) == 1
         assert len(new_data_events) == 2
         assert new_data_events[1].run is run
+        assert new_data_events[0].updated == {"primary": 3}
         assert len(completed_events) == 0
 
     # Exiting the context issues a 'stop' document....


### PR DESCRIPTION
In the case of plotting, we really want to update the whole-of-data set as we get new data (because we can set a full line / scatter / whatever worth of data down to the next layer), but for something like a table where the underlying structures have nice append behavior baked in (e.g. printing to the screen!) getting just the new data is nice.   

Also implements @danielballan 's suggest from #11 to include the stream and number of new rows in the `new_data` event so if you want to re-create the document stream from the xarrays you do not have to keep track of the growth call-to-call.

In addition to reverse engineering event/event pages back out of `BlueskyRun`, re-emit the documents directly.

This makes getting LiveTable to work again straight forward (it already consumes a document stream and has the ability to re-direct its output text stream so there is a quick path to embedding it qt / jupyter).