### PR TITLE
Line painter issue fix

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,26 @@
+name: Check Code Style
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - name: Install flake8
+        shell: bash -l {0}
+        run: |
+          set -vxeuo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+          python -m pip list
+
+      - name: Run flake8
+        shell: bash -l {0}
+        run: flake8

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,42 @@
+name: Unit Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+      - cron: '00 4 * * *'  # daily at 4AM
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+      fail-fast: false
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      shell: bash -l {0}
+      run: source continuous_integration/scripts/install.sh
+
+    - name: Install test requirements
+      shell: bash -l {0}
+      run: |
+        set -vxeuo pipefail
+        python -m pip install -r requirements-dev.txt
+        python -m pip list
+
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        set -vxeuo pipefail
+        coverage run -m pytest -v
+        coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     steps:
 

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -126,7 +126,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
         self.descriptors[doc["uid"]] = doc
         if name is not None and name not in self._streams:
             self._streams[name] = [doc]
-            self.new_data_events.add(name=Event)
+            self.new_data_events.add(**{name: Event})
             self.events.new_stream(name=name)
         else:
             self._streams[name].append(doc)

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -472,7 +472,8 @@ class BlueskyEventStream:
         # else:
         # data totally fits into current blocks we have
         offset = self.block_edges[-2]
-        for key, block in self.blocks.items():
+        for key, blocks in self.blocks.items():
+            block = blocks[-1]
             block[event.first_seq_num - 1 - offset:event.first_seq_num - 1 + event.num_rows - offset] = event_page["data"][key]
 
     @property

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -507,7 +507,7 @@ class BlueskyEventStream:
                     block[
                         event.first_seq_num
                         - 1
-                        - offset: event.first_seq_num
+                        - offset : event.first_seq_num  # noqa: E203
                         - 1
                         + event.num_rows
                         - offset
@@ -516,7 +516,7 @@ class BlueskyEventStream:
                     time_block[
                         event.first_seq_num
                         - 1
-                        - offset: event.first_seq_num
+                        - offset : event.first_seq_num  # noqa: E203
                         - 1
                         + event.num_rows
                         - offset
@@ -533,7 +533,7 @@ class BlueskyEventStream:
                 block[
                     event.first_seq_num
                     - 1
-                    - offset: event.first_seq_num
+                    - offset : event.first_seq_num  # noqa: E203
                     - 1
                     + event.num_rows
                     - offset
@@ -541,7 +541,7 @@ class BlueskyEventStream:
                 time_block[
                     event.first_seq_num
                     - 1
-                    - offset: event.first_seq_num
+                    - offset : event.first_seq_num  # noqa: E203
                     - 1
                     + event.num_rows
                     - offset

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -500,13 +500,14 @@ class BlueskyEventStream:
                     block = blocks[-1]
                     time_block = self.time_blocks[-1]
                 else:
-                    # We have multiple blocks and we need to fill the unfilled spots in the second most recent block
+                    # We have multiple blocks and we need to fill the unfilled spots
+                    # in the second most recent block
                     block = blocks[-2]
                     time_block = self.time_blocks[-2]
                     block[
                         event.first_seq_num
                         - 1
-                        - offset : event.first_seq_num
+                        - offset: event.first_seq_num
                         - 1
                         + event.num_rows
                         - offset
@@ -515,7 +516,7 @@ class BlueskyEventStream:
                     time_block[
                         event.first_seq_num
                         - 1
-                        - offset : event.first_seq_num
+                        - offset: event.first_seq_num
                         - 1
                         + event.num_rows
                         - offset
@@ -532,7 +533,7 @@ class BlueskyEventStream:
                 block[
                     event.first_seq_num
                     - 1
-                    - offset : event.first_seq_num
+                    - offset: event.first_seq_num
                     - 1
                     + event.num_rows
                     - offset
@@ -540,7 +541,7 @@ class BlueskyEventStream:
                 time_block[
                     event.first_seq_num
                     - 1
-                    - offset : event.first_seq_num
+                    - offset: event.first_seq_num
                     - 1
                     + event.num_rows
                     - offset

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -103,6 +103,7 @@ class DocumentCache(event_model.SingleRunDocumentRouter):
             updated={name: len(doc["seq_num"])}
         )
         self.new_data_events[name](
+            descriptor_uid=doc["descriptor"],
             num_rows=len(doc["seq_num"]),
             first_seq_num=doc["seq_num"][0],
             update_index=len(self.event_pages[doc["descriptor"]]) - 1
@@ -460,7 +461,7 @@ class BlueskyEventStream:
     def _on_new_data(self, event):
         # do we need new blocks
         requested_rows = (event.first_seq_num - 1 + event.num_rows) - self.allocated_rows
-        event_page = self._document_cache.event_pages[self._stream_name][event.update_index]
+        event_page = self._document_cache.event_pages[event.descriptor_uid][event.update_index]
         if requested_rows > 0:
             self._allocate_blocks(requested_rows)
             # TODO

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -471,7 +471,10 @@ class BlueskyEventStream:
         num_rows = max(EVENTS_PER_BLOCK, requested_rows)
         for key in self.blocks:
             self.blocks[key].append(
-                numpy.empty((num_rows, *self.data_keys[key]["shape"]), dtype=JSON_DTYPE_TO_MACHINE_DATA_TYPE[self.data_keys[key]["dtype"]])
+                numpy.empty(
+                    (num_rows, *self.data_keys[key]["shape"]),
+                    dtype=JSON_DTYPE_TO_MACHINE_DATA_TYPE[self.data_keys[key]["dtype"]],
+                )
             )
             self.time_blocks.append(numpy.empty((num_rows,)))
         self.allocated_rows += num_rows
@@ -604,7 +607,13 @@ class BlueskyEventStream:
 
     def to_dask(self):
         ds = self.read()
-        return xarray.Dataset({key: xarray.DataArray(dask.array.from_array(value), dims=value.dims) for key, value in ds.items()}, coords=ds.coords)
+        return xarray.Dataset(
+            {
+                key: xarray.DataArray(dask.array.from_array(value), dims=value.dims)
+                for key, value in ds.items()
+            },
+            coords=ds.coords,
+        )
 
 
 def _ft(timestamp):

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -5,6 +5,7 @@ import functools
 import threading
 
 import event_model
+import numpy
 
 from .document import Start, Stop, Descriptor
 from .event import EmitterGroup, Event

--- a/bluesky_live/bluesky_run.py
+++ b/bluesky_live/bluesky_run.py
@@ -442,10 +442,14 @@ class BlueskyEventStream:
         self._get_filler = get_filler
         self._transform = transform
         self.config = ConfigAccessor(self)
-        # dict of lists of arrays
-        self.blocks = {key: [] for key in self._document_cache.descriptors.keys()}
+        # We need the data_keys, which are the same for any descriptor in this
+        # stream, so we can grab the first one.
+        descriptor = self._document_cache.streams[self._stream_name][0]
+        data_keys = descriptor["data_keys"]
         # shape for evey block; use to determine shape needed later on
-        self.shapes = {key: descriptor[key]["shape"] for key, descriptor in self._document_cache.descriptors.items()}
+        self.shapes = {key: data_key["shape"] for key, data_key in data_keys.items()}
+        # dict of lists of arrays
+        self.blocks = {key: [] for key in data_keys}
         self.allocated_rows = 0
         self.block_edges = [0]
         self._document_cache.new_data_events[self._stream_name].connect(self._on_new_data)

--- a/bluesky_live/event.py
+++ b/bluesky_live/event.py
@@ -509,8 +509,7 @@ class EventEmitter:
                 for cb in rem:
                     self.disconnect(cb)
             finally:
-                pop_source_var = event._pop_source()
-                if pop_source_var is not self.source:
+                if event._pop_source() is not self.source:
                     raise RuntimeError("Event source-stack mismatch.")
 
             return event

--- a/bluesky_live/run_builder.py
+++ b/bluesky_live/run_builder.py
@@ -205,7 +205,9 @@ class RunBuilder:
         if timestamps is None:
             timestamps = {k: [now] * len_ for k in data}
         if seq_num is None:
-            seq_num = (self._next_seq_num[name] + numpy.arange(len_, dtype=int)).tolist()
+            seq_num = (
+                self._next_seq_num[name] + numpy.arange(len_, dtype=int)
+            ).tolist()
         self._next_seq_num[name] = 1 + seq_num[-1]
         bundle = self._streams[name]
         doc = bundle.compose_event_page(

--- a/bluesky_live/run_builder.py
+++ b/bluesky_live/run_builder.py
@@ -76,6 +76,7 @@ class RunBuilder:
         self._cache.start(self._run_bundle.start_doc)
         # maps stream name to bundle returned by compose_descriptor
         self._streams = {}
+        self._next_seq_num = {}
 
     def add_stream(
         self,
@@ -154,6 +155,7 @@ class RunBuilder:
             hints=hints,
         )
         self._streams[name] = bundle
+        self._next_seq_num[name] = 1
         self._cache.descriptor(bundle.descriptor_doc)
         if data is not None:
             self.add_data(name=name, data=data, time=time)
@@ -203,7 +205,8 @@ class RunBuilder:
         if timestamps is None:
             timestamps = {k: [now] * len_ for k in data}
         if seq_num is None:
-            seq_num = (1 + numpy.arange(len_, dtype=int)).tolist()
+            seq_num = (self._next_seq_num[name] + numpy.arange(len_, dtype=int)).tolist()
+        self._next_seq_num[name] = 1 + seq_num[-1]
         bundle = self._streams[name]
         doc = bundle.compose_event_page(
             time=time,

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -195,7 +195,11 @@ def test_blocks_big_enough_for_new_data():
                 "b": {"shape": [], "dtype": "integer", "source": "whatever"},
             },
         )
-        builder.add_data("primary", {"a": [1, 2, 3, 4, 5, 6], "b": [7, 8, 9, 10, 11, 12]})
+        builder.add_data(
+            "primary", {"a": [1, 2, 3, 4, 5, 6], "b": [7, 8, 9, 10, 11, 12]}
+        )
         run.primary.read()
-        builder.add_data("primary", {"a": [13, 14, 15, 16, 17, 18], "b": [19, 20, 21, 22, 23, 24]})
+        builder.add_data(
+            "primary", {"a": [13, 14, 15, 16, 17, 18], "b": [19, 20, 21, 22, 23, 24]}
+        )
         run.primary.read()

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -143,9 +143,59 @@ def test_event_stream_blocks():
                 "b": {"shape": [], "dtype": "integer", "source": "whatever"},
             },
         )
-        builder.add_data("primary", {"a": [1, 2, 3], "b": [5, 6, 7]})
-        builder.add_data("primary", {"a": [4], "b": [8]})
-        builder.add_data("primary", {"a": [9], "b": [12]})
-        builder.add_data("primary", {"a": [10], "b": [13]})
-        builder.add_data("primary", {"a": [11], "b": [14]})
+        builder.add_data("primary", {"a": [1, 2, 3], "b": [4, 5, 6]})
+        builder.add_data("primary", {"a": [7], "b": [8]})
+        builder.add_data("primary", {"a": [9], "b": [10]})
+        builder.add_data("primary", {"a": [11], "b": [12]})
     run.primary.read()
+
+
+def test_new_data_starts_new_block():
+    # Test when the new data starts cleanly in a new block
+    with RunBuilder() as builder:
+        run = builder.get_run()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "a": {"shape": [], "dtype": "integer", "source": "whatever"},
+                "b": {"shape": [], "dtype": "integer", "source": "whatever"},
+            },
+        )
+        builder.add_data("primary", {"a": [1, 2, 3, 4, 5], "b": [6, 7, 8, 9, 10]})
+        builder.add_data("primary", {"a": [11], "b": [12]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [13, 14, 15, 16], "b": [17, 18, 19, 20]})
+        run.primary.read()
+
+
+def test_new_data_fills_one_block_and_needs_another():
+    # Test when the 1st block needs to be filled and another block is needed
+    with RunBuilder() as builder:
+        run = builder.get_run()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "a": {"shape": [], "dtype": "integer", "source": "whatever"},
+                "b": {"shape": [], "dtype": "integer", "source": "whatever"},
+            },
+        )
+        builder.add_data("primary", {"a": [1, 2, 3], "b": [7, 8, 9]})
+        builder.add_data("primary", {"a": [4, 5, 6], "b": [10, 11, 12]})
+    run.primary.read()
+
+
+def test_blocks_big_enough_for_new_data():
+    # Test the first block starts with enough rows for initial data
+    with RunBuilder() as builder:
+        run = builder.get_run()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "a": {"shape": [], "dtype": "integer", "source": "whatever"},
+                "b": {"shape": [], "dtype": "integer", "source": "whatever"},
+            },
+        )
+        builder.add_data("primary", {"a": [1, 2, 3, 4, 5, 6], "b": [7, 8, 9, 10, 11, 12]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [13, 14, 15, 16, 17, 18], "b": [19, 20, 21, 22, 23, 24]})
+        run.primary.read()

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -131,3 +131,21 @@ def test_write_lock():
         assert bool(len(run.primary.read()["a"]))
         thread.join()
         assert not failed.is_set()
+
+
+def test_event_stream_blocks():
+    with RunBuilder() as builder:
+        run = builder.get_run()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "a": {"shape": [], "dtype": "integer", "source": "whatever"},
+                "b": {"shape": [], "dtype": "integer", "source": "whatever"},
+            },
+        )
+        builder.add_data("primary", {"a": [1, 2, 3], "b": [5, 6, 7]})
+        builder.add_data("primary", {"a": [4], "b": [8]})
+        builder.add_data("primary", {"a": [9], "b": [12]})
+        builder.add_data("primary", {"a": [10], "b": [13]})
+        builder.add_data("primary", {"a": [11], "b": [14]})
+    run.primary.read()

--- a/bluesky_live/tests/test_bluesky_run.py
+++ b/bluesky_live/tests/test_bluesky_run.py
@@ -147,7 +147,33 @@ def test_event_stream_blocks():
         builder.add_data("primary", {"a": [7], "b": [8]})
         builder.add_data("primary", {"a": [9], "b": [10]})
         builder.add_data("primary", {"a": [11], "b": [12]})
-    run.primary.read()
+        run.primary.read()
+
+
+def test_add_data_one_at_a_time():
+    with RunBuilder() as builder:
+        run = builder.get_run()
+        builder.add_stream(
+            "primary",
+            data_keys={
+                "a": {"shape": [], "dtype": "integer", "source": "whatever"},
+                "b": {"shape": [], "dtype": "integer", "source": "whatever"},
+            },
+        )
+        builder.add_data("primary", {"a": [1], "b": [2]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [3], "b": [4]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [5], "b": [6]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [7], "b": [8]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [9], "b": [10]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [11], "b": [12]})
+        run.primary.read()
+        builder.add_data("primary", {"a": [13], "b": [14]})
+        run.primary.read()
 
 
 def test_new_data_starts_new_block():

--- a/bluesky_live/tests/test_run_builder.py
+++ b/bluesky_live/tests/test_run_builder.py
@@ -153,5 +153,5 @@ def test_add_stream_from_data_keys_with_extras():
 
 def test_boolean_data():
     with RunBuilder() as builder:
-        builder.add_stream("primary", data=[True, False, True])
+        builder.add_stream("primary", data={"a": [True, False, True]})
     builder.get_run()

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -9,5 +9,5 @@ python -m pip install --upgrade pip setuptools wheel numpy
 # Versioneer uses the most recent git tag to generate __version__, which appears
 # in the published documentation.
 git fetch --tags
-python -m pip install .
+python -m pip install . -v
 python -m pip list

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -vxeuo pipefail
+
+# These packages are installed in the base environment but may be older
+# versions. Explicitly upgrade them because they often create
+# installation problems if out of date.
+python -m pip install --upgrade pip setuptools wheel numpy
+# Versioneer uses the most recent git tag to generate __version__, which appears
+# in the published documentation.
+git fetch --tags
+python -m pip install .
+python -m pip list

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_cli = True
+log_cli_format = %(asctime)s - %(name)s - %(levelname)s - %(message)s
+log_cli_level = WARNING


### PR DESCRIPTION
In this PR:
- A debounce decorator function to space out function calls
- Locking on `EventEmitter` callbacks
- Instead of recreating an xarray `Dataset` every time new data comes in, allocate blocks of space, update the blocks with the new data, allocate more space when the current blocks are filled, and create a `Dataset` made of all the blocks when `read()` is called
- Additional tests for the new data block change
- A bug fix for `RunBuilder` `seq_num`

To Do:
- Add support back in for filled data
- Add a test for filled data